### PR TITLE
Added intial information for FerriteCon 2026

### DIFF
--- a/2026/index.md
+++ b/2026/index.md
@@ -1,0 +1,55 @@
++++
+title = "Ferrite.jl Conference 2026"
+hascode = false
+hasmath = false
++++
+
+# FerriteCon 2026
+FerriteCon 2026 will take place at the [Technische Universität Braunschweig](https://www.tu-braunschweig.de/en/) (TU Braunschweig) in Braunschweig, Germany, on 24 September 2026.
+
+## Ferrite.jl User & Developer Conference 2026
+[Ferrite.jl](https://ferrite-fem.github.io/Ferrite.jl/stable/) is an open-source finite element package written in the [Julia programming
+language](https://julialang.org/). On Thursday the 24th of September 2026 we will host the fifth annual Ferrite.jl user and developer conference at TU Braunschweig.
+
+The conference aims to improve existing, and find new, technical and scientific collaborations among Ferrite.jl users and developers, as well as to discuss how the package can be further developed in the future. The conference will consist of both beginner-friendly and advanced presentations on Ferrite.jl and of current research using Ferrite.jl.
+
+## Schedule
+The detailed schedule will be announced closer to the date.
+
+You can also have a look at the program of previous editions of FerriteCon:
+- [FerriteCon 2022 (Braunschweig, Germany)](/2022/)
+- [FerriteCon 2023 (Bochum, Germany)](/2023/)
+- [FerriteCon 2024 (Gothenburg, Sweden)](/2024/)
+- [FerriteCon 2025 (Lyngby, Denmark)](/2025/)
+
+## Speaker information
+Regular talks are 15min + 5 mins for questions. We will live-stream the conference via Microsoft Teams and record the talks,
+in order to upload them on the [JuliaLang Youtube channel](https://www.youtube.com/c/TheJuliaLanguage).
+If you do not consent to this, please contact the organizers and we will exclude your talk from the uploaded videos.
+You can present from your own laptop, in this case please make sure that you can share your slides in a Teams meeting so that our recording will include the slides.
+The room is equipped with video / audio equipment, and we will be available in the conference room from 8:30 on the day so that you can try connecting your computer.
+
+## Public transport
+If you need to use public transport in Braunschweig, you can buy single tickets from the driver or, usually more conveniently, via the [Meine BSVG](https://www.bsvg.net/) or [VRB Fahrinfo & Tickets](https://www.vrb-online.de/en/service/app) apps ([Fairtiq](https://fairtiq.com/en/vrb), a check-in / check-out app, is also available). For trains to Braunschweig, use [Deutsche Bahn (DB Navigator)](https://www.bahn.de/). All are available as apps.
+
+## Conference topics
+
+If you have experience with Ferrite.jl we encourage you to contribute to the conference by giving a presentation. Here are some suggested topics that would fit well:
+
+* Present your research and how you use Ferrite.jl (take this opportunity to discuss implementation aspects which are normally not discussed much on regular scientific conferences!)
+* Present interesting synergies between Ferrite.jl and the rest of the Julia package ecosystem
+* Present how you use Ferrite.jl for teaching or for student projects
+* Describe what you would like to use Ferrite.jl for, and the reasons why you are currently using something else.
+* Present ideas for future Ferrite.jl improvements and describe how you would like to incorporate it (perhaps describe prior art from other software packages)
+
+If you have another topic you would like to discuss, please feel free to do so, as long as you can relate it to Ferrite.jl!
+
+The conference and meetup is free of charge, but registration is necessary. To register as a speaker, please send an email containing a title and a brief abstract (~100 words, 3-4 sentences) to Quoc Tuan La ([quoc-tuan.la@tu-braunschweig.de](mailto:quoc-tuan.la@tu-braunschweig.de)) at the latest the **28th of August (2026-08-28)**. If you want to attend without presenting, please register as soon as possible, but latest the **18th of September (2026-09-18)**.
+
+
+## Contact
+If you have any questions, please don't hesitate to ask by sending an email to
+the organizers:
+
+* Quoc Tuan La ([quoc-tuan.la@tu-braunschweig.de](mailto:quoc-tuan.la@tu-braunschweig.de))
+* Mischa Blaszczyk ([mischa.blaszczyk@tu-braunschweig.de](mailto:mischa.blaszczyk@tu-braunschweig.de))

--- a/index.html
+++ b/index.html
@@ -2,6 +2,6 @@
 <html>
   <head>
     <!-- Redirect to current year -->
-    <meta http-equiv="refresh" content="0; url=/2025/">
+    <meta http-equiv="refresh" content="0; url=/2026/">
   </head>
 </html>


### PR DESCRIPTION
Sets up the FerriteCon 2026 webpage with:
- Event details: 24 September 2026 at TU Braunschweig, Germany
- Conference overview and aims
- Speaker information and talk guidelines
- Public transport and registration details
- Links to previous FerriteCon editions and conference topics